### PR TITLE
go.mod: Update for repository move

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cgwalters/rpmostree-client-go
+module github.com/coreos/rpmostree-client-go
 
 go 1.17
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -61,7 +61,7 @@ func (client *Client) run(args ...string) error {
 	return c.Run()
 }
 
-/// VersionData represents the static information about rpm-ostree.
+// VersionData represents the static information about rpm-ostree.
 type VersionData struct {
 	Version  string   `json:"version"`
 	Features []string `json:"features"`


### PR DESCRIPTION
Now that https://github.com/coreos/fedora-coreos-tracker/issues/1284 is done.