### PR TITLE
Fix version parsing

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -63,8 +63,13 @@ func (client *Client) run(args ...string) error {
 
 // VersionData represents the static information about rpm-ostree.
 type VersionData struct {
-	Version  string   `json:"version"`
-	Features []string `json:"features"`
+	Version  string   `yaml:"Version"`
+	Features []string `yaml:"Features"`
+	Git      string   `yaml:"Git"`
+}
+
+type rpmOstreeVersionData struct {
+	Root VersionData `yaml:"rpm-ostree"`
 }
 
 // RpmOstreeVersion returns the running rpm-ostree version number
@@ -75,12 +80,12 @@ func (client *Client) RpmOstreeVersion() (*VersionData, error) {
 		return nil, err
 	}
 
-	var q VersionData
+	var q rpmOstreeVersionData
 	if err := yaml.Unmarshal(buf, &q); err != nil {
 		return nil, fmt.Errorf("failed to parse `rpm-ostree --version` output: %w", err)
 	}
 
-	return &q, nil
+	return &q.Root, nil
 }
 
 func compareVersionStrings(required, actual string) (bool, error) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewClient(t *testing.T) {
@@ -24,6 +25,25 @@ func TestCompareVersionStrings(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, v)
 	}
+}
+
+func TestParseVersion(t *testing.T) {
+	verdata := `rpm-ostree:
+  Version: '2022.10'
+  Git: 6b302116c969397fd71899e3b9bb3b8c100d1af9
+  Features:
+   - rust
+   - compose
+   - rhsm
+`
+	var q rpmOstreeVersionData
+	if err := yaml.Unmarshal([]byte(verdata), &q); err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, "2022.10", q.Root.Version)
+	assert.Contains(t, q.Root.Features, "rust")
+	assert.NotContains(t, q.Root.Features, "container")
 }
 
 // Stubbed out tests below that depend on a running rpm-ostree system


### PR DESCRIPTION
I'd swear I tested this, but apparently not.  Rust's serde is so much nicer at this instead of having to remember to use `yaml:` instead of `json:` when parsing YAML.