### PR TITLE
Add `BaseChecksum` and API, as well as test fixtures for status JSON

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,6 +25,7 @@ type Deployment struct {
 	ID                      string   `json:"id"`
 	OSName                  string   `json:"osname"`
 	Serial                  int32    `json:"serial"`
+	BaseChecksum            *string  `json:"base-checksum"`
 	Checksum                string   `json:"checksum"`
 	Version                 string   `json:"version"`
 	Timestamp               uint64   `json:"timestamp"`
@@ -157,6 +158,14 @@ func (s *Status) GetStagedDeployment() *Deployment {
 		}
 	}
 	return nil
+}
+
+// GetBaseChecksum returns the ostree commit used as a base.
+func (s *Deployment) GetBaseChecksum() string {
+	if s.BaseChecksum != nil {
+		return *s.BaseChecksum
+	}
+	return s.Checksum
 }
 
 // Remove the pending deployment.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,11 +1,19 @@
 package client
 
 import (
+	_ "embed"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
+
+//go:embed test-fixtures/workstation-status.json
+var workstationFixture string
+
+//go:embed test-fixtures/fcos-container-status.json
+var fcosFixture string
 
 func TestNewClient(t *testing.T) {
 	c := NewClient("test")
@@ -44,6 +52,38 @@ func TestParseVersion(t *testing.T) {
 	assert.Equal(t, "2022.10", q.Root.Version)
 	assert.Contains(t, q.Root.Features, "rust")
 	assert.NotContains(t, q.Root.Features, "container")
+}
+
+func TestParseWorkstation(t *testing.T) {
+	var s Status
+
+	if err := json.Unmarshal([]byte(workstationFixture), &s); err != nil {
+		panic(err)
+	}
+
+	booted, err := s.GetBootedDeployment()
+	assert.Nil(t, err)
+	assert.NotNil(t, booted)
+
+	assert.Equal(t, booted.GetBaseChecksum(), "229387d3c0bb8ad698228ca5702eca72aed8b298a7c800be1dc72bab160a9f7f")
+}
+
+func TestParseFcos(t *testing.T) {
+	var s Status
+
+	if err := json.Unmarshal([]byte(fcosFixture), &s); err != nil {
+		panic(err)
+	}
+
+	booted, err := s.GetBootedDeployment()
+	assert.Nil(t, err)
+	assert.NotNil(t, booted)
+	assert.Equal(t, booted.ContainerImageReference, "")
+
+	assert.Equal(t, booted.GetBaseChecksum(), "a465c49fef185f8339d3cd5857e28386cfdc6516f68206912917c9dc3192d809")
+
+	firstDeploy := s.Deployments[0]
+	assert.Equal(t, firstDeploy.ContainerImageReference, "ostree-unverified-registry:quay.io/fedora/fedora-coreos:testing-devel")
 }
 
 // Stubbed out tests below that depend on a running rpm-ostree system

--- a/pkg/client/test-fixtures/fcos-container-status.json
+++ b/pkg/client/test-fixtures/fcos-container-status.json
@@ -1,0 +1,82 @@
+{
+    "deployments": [
+        {
+            "unlocked": "none",
+            "requested-local-packages": [],
+            "base-removals": [],
+            "requested-modules": [],
+            "requested-modules-enabled": [],
+            "pinned": false,
+            "osname": "fedora-coreos",
+            "base-remote-replacements": {},
+            "regenerate-initramfs": false,
+            "checksum": "7239c56aa4fe6208008fa2800e16e2ccc68179f776674c3a90b1d4c71f2b80ca",
+            "container-image-reference-digest": "sha256:25d3a07d53835c6c738fb4dcba149dc0b64a9bc4ec9c3431750cabd3596ab233",
+            "requested-base-local-replacements": [],
+            "id": "fedora-coreos-7239c56aa4fe6208008fa2800e16e2ccc68179f776674c3a90b1d4c71f2b80ca.0",
+            "modules": [],
+            "requested-local-fileoverride-packages": [],
+            "requested-base-removals": [],
+            "requested-packages": [],
+            "serial": 0,
+            "timestamp": 1663794115,
+            "staged": true,
+            "booted": false,
+            "container-image-reference": "ostree-unverified-registry:quay.io/fedora/fedora-coreos:testing-devel",
+            "packages": [],
+            "base-local-replacements": []
+        },
+        {
+            "unlocked": "none",
+            "requested-local-packages": [],
+            "base-removals": [],
+            "requested-modules": [],
+            "requested-modules-enabled": [],
+            "pinned": false,
+            "osname": "fedora-coreos",
+            "base-remote-replacements": {},
+            "origin": "fedora:fedora/x86_64/coreos/stable",
+            "regenerate-initramfs": false,
+            "checksum": "a465c49fef185f8339d3cd5857e28386cfdc6516f68206912917c9dc3192d809",
+            "gpg-enabled": true,
+            "requested-base-local-replacements": [],
+            "id": "fedora-coreos-a465c49fef185f8339d3cd5857e28386cfdc6516f68206912917c9dc3192d809.0",
+            "version": "36.20220820.3.0",
+            "requested-local-fileoverride-packages": [],
+            "requested-base-removals": [],
+            "signatures": [
+                [
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    "53DED2CB922D8B8D9E63FD18999F7CBF38AB71F4",
+                    1662489044,
+                    0,
+                    "RSA",
+                    "SHA256",
+                    "Fedora",
+                    "fedora-36-primary@fedoraproject.org",
+                    "53DED2CB922D8B8D9E63FD18999F7CBF38AB71F4",
+                    0,
+                    0
+                ]
+            ],
+            "requested-packages": [],
+            "serial": 0,
+            "timestamp": 1662488373,
+            "staged": false,
+            "booted": true,
+            "packages": [],
+            "base-local-replacements": [],
+            "modules": []
+        }
+    ],
+    "transaction": null,
+    "cached-update": null,
+    "update-driver": {
+        "driver-name": "Zincati",
+        "driver-sd-unit": "zincati.service"
+    }
+}

--- a/pkg/client/test-fixtures/workstation-status.json
+++ b/pkg/client/test-fixtures/workstation-status.json
@@ -1,0 +1,303 @@
+{
+    "deployments": [
+        {
+            "unlocked": "none",
+            "base-commit-meta": {
+                "coreos-assembler.config-gitrev": "80966f951c766846da070b4c168b9170c61513e2",
+                "coreos-assembler.config-dirty": "false",
+                "rpmostree.inputhash": "06539cc4a4265eec2045a349fe80de451a61628c1b117e171d80663d3e3f42eb",
+                "coreos-assembler.basearch": "x86_64",
+                "version": "33.21",
+                "rpmostree.initramfs-args": [
+                    "--add=ignition",
+                    "--no-hostonly",
+                    "--omit=nfs",
+                    "--omit=lvm",
+                    "--omit=iscsi"
+                ],
+                "rpmostree.rpmmd-repos": [
+                    {
+                        "id": "fedora-coreos-pool",
+                        "timestamp": 1053029086517002240
+                    },
+                    {
+                        "id": "fedora",
+                        "timestamp": -2945197617627267072
+                    },
+                    {
+                        "id": "fedora-updates",
+                        "timestamp": -389530169125109760
+                    }
+                ]
+            },
+            "requested-local-packages": [],
+            "base-removals": [],
+            "gpg-enabled": false,
+            "origin": "fedora/33/x86_64/silverblue",
+            "osname": "fedora-silverblue",
+            "pinned": false,
+            "requested-base-local-replacements": [
+                "rpm-ostree-2021.1-2.fc33.x86_64",
+                "rpm-ostree-libs-2021.1-2.fc33.x86_64"
+            ],
+            "checksum": "63335a77f9853618ba1a5f139c5805e82176a2a040ef5e34d7402e12263af5bb",
+            "regenerate-initramfs": false,
+            "id": "fedora-silverblue-63335a77f9853618ba1a5f139c5805e82176a2a040ef5e34d7402e12263af5bb.0",
+            "version": "33.21",
+            "base-version": "33.21",
+            "requested-base-removals": [],
+            "base-checksum": "229387d3c0bb8ad698228ca5702eca72aed8b298a7c800be1dc72bab160a9f7f",
+            "requested-packages": [
+                "xsel",
+                "gdb",
+                "ykclient",
+                "krb5-workstation",
+                "ykpers",
+                "git-evtag",
+                "fish",
+                "qemu-system-aarch64",
+                "strace",
+                "qemu-kvm",
+                "virt-manager",
+                "opensc",
+                "tmux",
+                "pcsc-lite-ccid",
+                "tilix",
+                "libvirt"
+            ],
+            "base-timestamp": 1612554510,
+            "serial": 0,
+            "layered-commit-meta": {
+                "rpmostree.clientlayer": true,
+                "version": "33.21",
+                "rpmostree.clientlayer_version": 4,
+                "rpmostree.state-sha512": "8b037fba282e3773ef17d4c396ee958765c01e85c7a6a29ec9df1bb2213022cf599da15ec4df982c4f0904012b165c4370a9f14b12c48d0684a66928c4f34b34",
+                "rpmostree.rpmmd-repos": [
+                    {
+                        "id": "fedora-cisco-openh264",
+                        "timestamp": 1598382634
+                    },
+                    {
+                        "id": "updates",
+                        "timestamp": 1612486906
+                    },
+                    {
+                        "id": "fedora",
+                        "timestamp": 1603150039
+                    }
+                ]
+            },
+            "base-local-replacements": [
+                [
+                    [
+                        "rpm-ostree-2021.1-2.fc33.x86_64",
+                        "rpm-ostree",
+                        0,
+                        "2021.1",
+                        "2.fc33",
+                        "x86_64"
+                    ],
+                    [
+                        "rpm-ostree-2021.1-3.fc33.x86_64",
+                        "rpm-ostree",
+                        0,
+                        "2021.1",
+                        "3.fc33",
+                        "x86_64"
+                    ]
+                ],
+                [
+                    [
+                        "rpm-ostree-libs-2021.1-2.fc33.x86_64",
+                        "rpm-ostree-libs",
+                        0,
+                        "2021.1",
+                        "2.fc33",
+                        "x86_64"
+                    ],
+                    [
+                        "rpm-ostree-libs-2021.1-3.fc33.x86_64",
+                        "rpm-ostree-libs",
+                        0,
+                        "2021.1",
+                        "3.fc33",
+                        "x86_64"
+                    ]
+                ]
+            ],
+            "timestamp": 1612555369,
+            "packages": [
+                "fish",
+                "gdb",
+                "git-evtag",
+                "krb5-workstation",
+                "libvirt",
+                "opensc",
+                "pcsc-lite-ccid",
+                "qemu-kvm",
+                "qemu-system-aarch64",
+                "strace",
+                "tilix",
+                "tmux",
+                "virt-manager",
+                "xsel",
+                "ykclient",
+                "ykpers"
+            ],
+            "booted": true,
+            "initramfs-etc": []
+        },
+        {
+            "unlocked": "none",
+            "pending-base-version": "33.21",
+            "base-commit-meta": {
+                "coreos-assembler.config-gitrev": "bbd5282b507c5b29e3a5f12e9da21f3aaa0f0e00",
+                "coreos-assembler.config-dirty": "false",
+                "rpmostree.inputhash": "f33469d0f6c5d5ce5e30345fa5b002a8e4ebf5ea397caad000bdc32cd74897a6",
+                "coreos-assembler.basearch": "x86_64",
+                "version": "33.17",
+                "rpmostree.initramfs-args": [
+                    "--add=ignition",
+                    "--no-hostonly",
+                    "--omit=nfs",
+                    "--omit=lvm",
+                    "--omit=iscsi"
+                ],
+                "rpmostree.rpmmd-repos": [
+                    {
+                        "id": "fedora-coreos-pool",
+                        "timestamp": 7926905303512121344
+                    },
+                    {
+                        "id": "fedora",
+                        "timestamp": -2945197617627267072
+                    },
+                    {
+                        "id": "fedora-updates",
+                        "timestamp": -6611277243593261056
+                    }
+                ]
+            },
+            "requested-local-packages": [],
+            "base-removals": [],
+            "gpg-enabled": false,
+            "osname": "fedora-silverblue",
+            "origin": "fedora/33/x86_64/silverblue",
+            "packages": [
+                "fish",
+                "gdb",
+                "git-evtag",
+                "krb5-workstation",
+                "libvirt",
+                "opensc",
+                "pcsc-lite-ccid",
+                "qemu-kvm",
+                "qemu-system-aarch64",
+                "strace",
+                "tilix",
+                "tmux",
+                "virt-manager",
+                "xsel",
+                "ykclient",
+                "ykpers"
+            ],
+            "pinned": false,
+            "requested-base-local-replacements": [
+                "rpm-ostree-2021.1-2.fc33.x86_64",
+                "rpm-ostree-libs-2021.1-2.fc33.x86_64"
+            ],
+            "checksum": "775d54e89bc74731ec27db04f12510c0269c8cbab3ad5e39e0a4d693231ef072",
+            "regenerate-initramfs": false,
+            "id": "fedora-silverblue-775d54e89bc74731ec27db04f12510c0269c8cbab3ad5e39e0a4d693231ef072.0",
+            "version": "33.17",
+            "base-version": "33.17",
+            "base-checksum": "deea0555cb7d3eb042df9a85d4efcbb9f70d778a9a9557715c0e398978233cd7",
+            "requested-base-removals": [],
+            "requested-packages": [
+                "xsel",
+                "gdb",
+                "ykclient",
+                "krb5-workstation",
+                "ykpers",
+                "git-evtag",
+                "fish",
+                "qemu-system-aarch64",
+                "strace",
+                "qemu-kvm",
+                "virt-manager",
+                "opensc",
+                "tmux",
+                "pcsc-lite-ccid",
+                "tilix",
+                "libvirt"
+            ],
+            "base-timestamp": 1611079148,
+            "serial": 0,
+            "layered-commit-meta": {
+                "rpmostree.clientlayer": true,
+                "version": "33.17",
+                "rpmostree.clientlayer_version": 4,
+                "rpmostree.state-sha512": "684f72c2b63379ee17a8f3055ccdfb3d54d255ed5bf1965788be21e804a0aff9e08620519dacaa34cc8cbad038474e8b0abbc68ee98988c547ad599f93ddcfa1",
+                "rpmostree.rpmmd-repos": [
+                    {
+                        "id": "fedora-cisco-openh264",
+                        "timestamp": 1598382634
+                    },
+                    {
+                        "id": "updates",
+                        "timestamp": 1611022500
+                    },
+                    {
+                        "id": "fedora",
+                        "timestamp": 1603150039
+                    }
+                ]
+            },
+            "base-local-replacements": [
+                [
+                    [
+                        "rpm-ostree-2021.1-2.fc33.x86_64",
+                        "rpm-ostree",
+                        0,
+                        "2021.1",
+                        "2.fc33",
+                        "x86_64"
+                    ],
+                    [
+                        "rpm-ostree-2020.10-1.fc33.x86_64",
+                        "rpm-ostree",
+                        0,
+                        "2020.10",
+                        "1.fc33",
+                        "x86_64"
+                    ]
+                ],
+                [
+                    [
+                        "rpm-ostree-libs-2021.1-2.fc33.x86_64",
+                        "rpm-ostree-libs",
+                        0,
+                        "2021.1",
+                        "2.fc33",
+                        "x86_64"
+                    ],
+                    [
+                        "rpm-ostree-libs-2020.10-1.fc33.x86_64",
+                        "rpm-ostree-libs",
+                        0,
+                        "2020.10",
+                        "1.fc33",
+                        "x86_64"
+                    ]
+                ]
+            ],
+            "timestamp": 1611081986,
+            "pending-base-timestamp": 1612554510,
+            "booted": false,
+            "pending-base-checksum": "229387d3c0bb8ad698228ca5702eca72aed8b298a7c800be1dc72bab160a9f7f",
+            "initramfs-etc": []
+        }
+    ],
+    "transaction": null,
+    "cached-update": null
+}


### PR DESCRIPTION
Add an API to get the base checksum; the MCO wants this.

While we're here add two test fixtures for the status JSON and use it in new unit tests.