### PR TITLE
Expose `RequestedPackages` and `RequestedBaseRemovals`

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -36,6 +36,8 @@ type Deployment struct {
 	Origin                  string   `json:"origin"`
 	CustomOrigin            []string `json:"custom-origin"`
 	ContainerImageReference string   `json:"container-image-reference"`
+	RequestedPackages       []string `json:"requested-packages"`
+	RequestedBaseRemovals   []string `json:"requested-base-removals"`
 }
 
 // Client is a handle for interacting with an rpm-ostree based system.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -13,7 +13,10 @@ import (
 var workstationFixture string
 
 //go:embed test-fixtures/fcos-container-status.json
-var fcosFixture string
+var fcosContainerFixture string
+
+//go:embed test-fixtures/fcos-with-overrides-status.json
+var fcosOverridesFixture string
 
 func TestNewClient(t *testing.T) {
 	c := NewClient("test")
@@ -66,12 +69,13 @@ func TestParseWorkstation(t *testing.T) {
 	assert.NotNil(t, booted)
 
 	assert.Equal(t, booted.GetBaseChecksum(), "229387d3c0bb8ad698228ca5702eca72aed8b298a7c800be1dc72bab160a9f7f")
+	assert.Equal(t, booted.RequestedPackages[0], "xsel")
 }
 
-func TestParseFcos(t *testing.T) {
+func TestParseFcosContainer(t *testing.T) {
 	var s Status
 
-	if err := json.Unmarshal([]byte(fcosFixture), &s); err != nil {
+	if err := json.Unmarshal([]byte(fcosContainerFixture), &s); err != nil {
 		panic(err)
 	}
 
@@ -84,6 +88,17 @@ func TestParseFcos(t *testing.T) {
 
 	firstDeploy := s.Deployments[0]
 	assert.Equal(t, firstDeploy.ContainerImageReference, "ostree-unverified-registry:quay.io/fedora/fedora-coreos:testing-devel")
+}
+
+func TestParseFcosWithOverrides(t *testing.T) {
+	var s Status
+
+	if err := json.Unmarshal([]byte(fcosOverridesFixture), &s); err != nil {
+		panic(err)
+	}
+
+	firstDeploy := s.Deployments[0]
+	assert.Equal(t, firstDeploy.RequestedBaseRemovals[0], "moby-engine")
 }
 
 func TestParseDeploymentError(t *testing.T) {

--- a/pkg/client/test-fixtures/fcos-with-overrides-status.json
+++ b/pkg/client/test-fixtures/fcos-with-overrides-status.json
@@ -1,0 +1,167 @@
+{
+  "deployments" : [
+    {
+      "requested-packages" : [
+        "strace"
+      ],
+      "requested-base-local-replacements" : [],
+      "requested-modules" : [],
+      "signatures" : [
+        [
+          true,
+          false,
+          false,
+          false,
+          false,
+          "ACB5EE4E831C74BB7C168D27F55AD3FB5323552A",
+          1675718597,
+          0,
+          "RSA",
+          "SHA256",
+          "Fedora",
+          "fedora-37-primary@fedoraproject.org",
+          "ACB5EE4E831C74BB7C168D27F55AD3FB5323552A",
+          0,
+          0
+        ]
+      ],
+      "regenerate-initramfs" : false,
+      "version" : "37.20230122.3.0",
+      "requested-local-fileoverride-packages" : [],
+      "base-commit-meta" : {
+        "coreos-assembler.config-gitrev" : "a315b777b7cf8ef529509adccd499e286df7c262",
+        "coreos-assembler.config-dirty" : "false",
+        "rpmostree.inputhash" : "e2b86c14978b4f10434462aa48cfb374a0c8b218e2cb5307a5399f7ed9be948f",
+        "coreos-assembler.basearch" : "x86_64",
+        "ostree.bootable" : true,
+        "fedora-coreos.stream" : "stable",
+        "version" : "37.20230122.3.0",
+        "ostree.linux" : "6.1.6-200.fc37.x86_64",
+        "ostree.container-cmd" : [
+          "/usr/bin/bash"
+        ],
+        "rpmostree.rpmmd-repos" : [
+          {
+            "id" : "fedora-coreos-pool",
+            "timestamp" : -4166427364441456640
+          }
+        ]
+      },
+      "base-remote-replacements" : {      },
+      "layered-commit-meta" : {
+        "rpmostree.clientlayer" : true,
+        "version" : "37.20230122.3.0",
+        "rpmostree.clientlayer_version" : 6,
+        "rpmostree.state-sha512" : "c9dc7a9264ed7dfc2d593b6311f77b1024597627aaab35e34d0f5f8ec57abc74afc38c925eac9536c52df9a1efcec1edd2f96db33388d0a156f2dc1803609976",
+        "rpmostree.rpmmd-repos" : [],
+        "ostree.linux" : "6.1.6-200.fc37.x86_64",
+        "ostree.bootable" : true
+      },
+      "timestamp" : 1677854637,
+      "packages" : [
+        "strace"
+      ],
+      "base-local-replacements" : [],
+      "osname" : "fedora-coreos",
+      "pinned" : false,
+      "modules" : [],
+      "requested-modules-enabled" : [],
+      "booted" : false,
+      "base-removals" : [
+        [
+          "moby-engine-20.10.22-1.fc37.x86_64",
+          "moby-engine",
+          0,
+          "20.10.22",
+          "1.fc37",
+          "x86_64"
+        ]
+      ],
+      "unlocked" : "none",
+      "requested-base-removals" : [
+        "moby-engine"
+      ],
+      "base-checksum" : "23bfcb638fcee121d5d257349c1c964b111f7df4e9895f602e671faa9ec7a607",
+      "id" : "fedora-coreos-683faf6b42711761e9af070a0f23f9b068ec2b81cc618debcc760b025621e27b.0",
+      "origin" : "fedora:fedora/x86_64/coreos/stable",
+      "serial" : 0,
+      "base-version" : "37.20230122.3.0",
+      "gpg-enabled" : true,
+      "base-timestamp" : 1675718468,
+      "requested-local-packages" : [],
+      "checksum" : "683faf6b42711761e9af070a0f23f9b068ec2b81cc618debcc760b025621e27b",
+      "staged" : true
+    },
+    {
+      "unlocked" : "none",
+      "requested-local-packages" : [],
+      "base-commit-meta" : {
+        "coreos-assembler.config-gitrev" : "a315b777b7cf8ef529509adccd499e286df7c262",
+        "coreos-assembler.config-dirty" : "false",
+        "rpmostree.inputhash" : "e2b86c14978b4f10434462aa48cfb374a0c8b218e2cb5307a5399f7ed9be948f",
+        "coreos-assembler.basearch" : "x86_64",
+        "ostree.bootable" : true,
+        "fedora-coreos.stream" : "stable",
+        "version" : "37.20230122.3.0",
+        "ostree.linux" : "6.1.6-200.fc37.x86_64",
+        "ostree.container-cmd" : [
+          "/usr/bin/bash"
+        ],
+        "rpmostree.rpmmd-repos" : [
+          {
+            "id" : "fedora-coreos-pool",
+            "timestamp" : -4166427364441456640
+          }
+        ]
+      },
+      "base-removals" : [],
+      "requested-modules" : [],
+      "requested-modules-enabled" : [],
+      "pinned" : false,
+      "osname" : "fedora-coreos",
+      "base-remote-replacements" : {      },
+      "origin" : "fedora:fedora/x86_64/coreos/stable",
+      "regenerate-initramfs" : false,
+      "checksum" : "23bfcb638fcee121d5d257349c1c964b111f7df4e9895f602e671faa9ec7a607",
+      "gpg-enabled" : true,
+      "requested-base-local-replacements" : [],
+      "id" : "fedora-coreos-23bfcb638fcee121d5d257349c1c964b111f7df4e9895f602e671faa9ec7a607.0",
+      "version" : "37.20230122.3.0",
+      "requested-local-fileoverride-packages" : [],
+      "requested-base-removals" : [],
+      "signatures" : [
+        [
+          true,
+          false,
+          false,
+          false,
+          false,
+          "ACB5EE4E831C74BB7C168D27F55AD3FB5323552A",
+          1675718597,
+          0,
+          "RSA",
+          "SHA256",
+          "Fedora",
+          "fedora-37-primary@fedoraproject.org",
+          "ACB5EE4E831C74BB7C168D27F55AD3FB5323552A",
+          0,
+          0
+        ]
+      ],
+      "requested-packages" : [],
+      "serial" : 0,
+      "timestamp" : 1675718468,
+      "staged" : false,
+      "booted" : true,
+      "packages" : [],
+      "base-local-replacements" : [],
+      "modules" : []
+    }
+  ],
+  "transaction" : null,
+  "cached-update" : null,
+  "update-driver" : {
+    "driver-name" : "Zincati",
+    "driver-sd-unit" : "zincati.service"
+  }
+}


### PR DESCRIPTION
I want to be able to parse which packages were in the current layering/overrides in https://github.com/openshift/machine-config-operator/pull/3485#issuecomment-1453602207 to aid the OpenShift MCO in handling kernel-rt changes.