### PR TITLE
client: add container-image-reference-digest field to Deployment

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,6 +40,7 @@ type Deployment struct {
 	Origin                             string                 `json:"origin"`
 	CustomOrigin                       []string               `json:"custom-origin"`
 	ContainerImageReference            string                 `json:"container-image-reference"`
+	ContainerImageReferenceDigest      string                 `json:"container-image-reference-digest"`
 	Packages                           []string               `json:"packages"`
 	RequestedPackages                  []string               `json:"requested-packages"`
 	RequestedLocalPackages             []string               `json:"requested-local-packages"`


### PR DESCRIPTION
This PR adds support for  container-image-reference-digest  as a root level field for Deployment. This is convenience vs needing to traverse `base-commit-meta`.